### PR TITLE
Add support for the SICStus Prolog and YAP backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,17 @@ querying Logtalk.
 
 Currently supports the following backends:
 
-- swilgt
 - eclipselgt
 - gplgt
+- sicstuslgt
+- swilgt
+- yaplgt
 
 Backends known to not be supported:
 
-- BProlog (doesn't support `variable_names/1` option to `write_term/2`, which
+- B-Prolog (doesn't support `variable_names/1` option to `write_term/2`, which
   is needed for `tkinter`)
-- CXProlog (no CLPFD)
+- CxProlog (no CLP(FD) library)
 
 ## Dependencies
 
@@ -34,9 +36,9 @@ For your convenience there's a bash run script provided:
 :~$ ./run
 ```
 
-Note, the application assumes the logtalk backend has been selected,
-i.e. the Tcl will call `logtalk` and expect that to be one of `swilgt`,
-`eclipselgt` or `gplgt`, which you can set with `logtalk_backend_select`.
+Note, the application assumes that one of the supported Logtalk backends
+listed above has been selected, i.e. the Tcl will call `logtalk` and expect
+that to be one set using the `logtalk_backend_select` script.
 
 If you wish to change this behaviour, the variable `load_cmd` in
 `lgt_query.lgt` is the thing you need to change.

--- a/loader.lgt
+++ b/loader.lgt
@@ -1,27 +1,25 @@
-:- if((
-	current_logtalk_flag(prolog_dialect, swi)
-)).
-% For SWI we need to load the library module
-:- initialization(use_module(library(clpfd))).
-
-:- elif((
-	current_logtalk_flag(prolog_dialect, eclipse)
-)).
-% For ECLiPSe we need to import CLPFD
-:- initialization(import(clpfd)).
-
-:- elif((
-	\+ current_logtalk_flag(prolog_dialect, gnu)
-)).
-% For GNU we don't need to load anything
-% BProlog doesn't support the variable_names option for `write_term/2`, needed for tkinter
-% CXProlog doesn't have CLPFD
-% Other backends aren't tested
-:- initialization((
-	write('Backend not supported, please use SWI, ECLiPSe, GNU, or BProlog'),
-	nl,
-	halt
-)).
+:- if(current_logtalk_flag(prolog_dialect, swi)).
+	% For SWI-Prolog we need to load the library module
+	:- use_module(library(clpfd)).
+:- elif(current_logtalk_flag(prolog_dialect, sicstus)).
+	% For SICStus Prolog we need to load the library module
+	:- use_module(library(clpfd)).
+:- elif(current_logtalk_flag(prolog_dialect, yap)).
+	% For YAP we need to load the library module
+	:- use_module(library(clpfd)).
+:- elif(current_logtalk_flag(prolog_dialect, eclipse)).
+	% For ECLiPSe we need to import CLPFD
+	:- import(clpfd).
+:- elif(\+ current_logtalk_flag(prolog_dialect, gnu)).
+	% For GNU we don't need to load anything
+	% BProlog doesn't support the variable_names option for `write_term/2`, needed for tkinter
+	% CXProlog doesn't have CLPFD
+	% Other backends aren't tested
+	:- initialization((
+		write('Backend not supported, please use SWI, ECLiPSe, GNU, or BProlog'),
+		nl,
+		halt
+	)).
 :- endif.
 
 

--- a/solver.lgt
+++ b/solver.lgt
@@ -1,31 +1,39 @@
 :- object(solver).
 
 	:- info([
-		version is 1:0:0,
+		version is 1:1:0,
 		author is 'Paul Brown',
-		date is 2021-06-26,
+		date is 2021-06-28,
 		comment is 'Solver advises on how many of each part to make'
 	]).
 
 	:- if((
 		current_logtalk_flag(prolog_dialect, swi) ;
+		current_logtalk_flag(prolog_dialect, yap) ;
 		current_logtalk_flag(prolog_dialect, eclipse)
 	)).
-	:- use_module(clpfd, [
-		(#=)/2,
-		(#=<)/2,
-		(#>=)/2,
-		labeling/2
-	]).
-	:- elif((
-		current_logtalk_flag(prolog_dialect, gnu)
-	)).
-	labeling(_Opts, [A, B, P]) :-
-		fd_labeling([P, A, B], [value_method(max)]).
+		:- use_module(clpfd, [
+			(#=)/2,
+			(#=<)/2,
+			(#>=)/2,
+			labeling/2
+		]).
+	:- elif(current_logtalk_flag(prolog_dialect, sicstus)).
+		:- use_module(clpfd, [
+			(#=)/2,
+			(#=<)/2,
+			(#>=)/2
+		]).
+		:- meta_predicate(clpfd:labeling(*, *)).
+		labeling([max(Var)], [A, B, P]) :-
+			clpfd:labeling([maximize(Var)], [A, B, P]).
+	:- elif(current_logtalk_flag(prolog_dialect, gnu)).
+		labeling(_Opts, [A, B, P]) :-
+			fd_labeling([P, A, B], [value_method(max)]).
 	:- endif.
 
 	:- public(solve/6).
-	:- mode(solve(+int, +int, +int, -int, -int, -int), zero_or_one).
+	:- mode(solve(+integer, +integer, +integer, -integer, -integer, -integer), zero_or_one).
 	:- info(solve/6, [
 		comment is 'Find an optimal solution for the given args',
 		argnames is [

--- a/tester.lgt
+++ b/tester.lgt
@@ -1,27 +1,25 @@
-:- if((
-	current_logtalk_flag(prolog_dialect, swi)
-)).
-% For SWI we need to load the library module
-:- initialization(use_module(library(clpfd))).
-
-:- elif((
-	current_logtalk_flag(prolog_dialect, eclipse)
-)).
-% For ECLiPSe we need to import CLPFD
-:- initialization(import(clpfd)).
-
-:- elif((
-	\+ current_logtalk_flag(prolog_dialect, gnu)
-)).
-% For GNU we don't need to load anything
-% BProlog doesn't support the variable_names option for `write_term/2`, needed for tkinter
-% CXProlog doesn't have CLPFD
-% Other backends aren't tested
-:- initialization((
-	write('Backend not supported, please use SWI, ECLiPSe, GNU, or BProlog'),
-	nl,
-	halt
-)).
+:- if(current_logtalk_flag(prolog_dialect, swi)).
+	% For SWI-Prolog we need to load the library module
+	:- use_module(library(clpfd)).
+:- elif(current_logtalk_flag(prolog_dialect, sicstus)).
+	% For SICStus Prolog we need to load the library module
+	:- use_module(library(clpfd)).
+:- elif(current_logtalk_flag(prolog_dialect, yap)).
+	% For YAP we need to load the library module
+	:- use_module(library(clpfd)).
+:- elif(current_logtalk_flag(prolog_dialect, eclipse)).
+	% For ECLiPSe we need to import CLPFD
+	:- import(clpfd).
+:- elif(\+ current_logtalk_flag(prolog_dialect, gnu)).
+	% For GNU we don't need to load anything
+	% BProlog doesn't support the variable_names option for `write_term/2`, needed for tkinter
+	% CXProlog doesn't have CLPFD
+	% Other backends aren't tested
+	:- initialization((
+		write('Backend not supported, please use SWI, ECLiPSe, GNU, or BProlog'),
+		nl,
+		halt
+	)).
 :- endif.
 
 :- initialization((


### PR DESCRIPTION
Note: The YAP git version of the CLP(FD) library is broken. Hopefully that's not the case in stable versions of YAP.